### PR TITLE
feat: encryption and bidirectional add script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,45 @@ project (the one that includes this repository as a submodule).
 
 ### Adding a new file
 
-To add a new file to be managed by `chezmoi`, use the `add` command. `chezmoi`
-will copy the file into its source directory, ready to be committed.
+To add a new file to be managed by `chezmoi`, you have two options:
+
+#### Option 1: Use the helper script (recommended for project files)
+
+The `chezmoi-add-secret.sh` script simplifies adding files from your project directory
+to chezmoi. It handles the limitation where chezmoi won't add files from directories
+it manages.
+
+```bash
+# Add a file
+./dotfile-utils/scripts/chezmoi-add-secret.sh .env
+
+# Add an encrypted file
+./dotfile-utils/scripts/chezmoi-add-secret.sh --encrypt .env
+
+# Show help
+./dotfile-utils/scripts/chezmoi-add-secret.sh --help
+```
+
+The script will:
+
+1. Copy the file to the chezmoi source directory with proper naming
+   (e.g., `.env` → `dot_env`)
+2. Add `encrypted_` prefix if `--encrypt` is used
+   (e.g., `.env` → `encrypted_dot_env`)
+3. Encrypt the file using GPG if encryption is enabled
+4. Apply changes to deploy the file back
+5. Stage the file in git for commit
+
+#### Option 2: Use chezmoi directly
+
+For files outside your project directory, use the standard `chezmoi add` command:
 
 ```bash
 # Add a configuration file
 chezmoi --config ./.chezmoi.toml add <filename>
+
+# Add an encrypted file (requires GPG encryption to be configured)
+chezmoi --config ./.chezmoi.toml add --encrypt <filename>
 ```
 
 ### Editing a file
@@ -164,7 +197,33 @@ variable to my_value, specify:
 using GPG. This is ideal for managing files with sensitive data, like shell history
 or private keys.
 
-To encrypt a file, add it with the `--encrypt` flag.
+#### Enabling Encryption During Bootstrap
+
+When running the bootstrap script for a new project, you'll be prompted to enable
+GPG encryption. You can also specify it via command-line flags:
+
+```bash
+# Enable encryption and let the script generate a new GPG key
+./dotfile-utils/bootstrap.sh --encrypt
+
+# Enable encryption with an existing GPG key
+./dotfile-utils/bootstrap.sh --encrypt --gpg-key <KEY_ID>
+```
+
+If you enable encryption, the bootstrap script will:
+
+1. Prompt you to either use an existing GPG key or generate a new one
+2. Generate a new 4096-bit RSA key (if creating new) with predefined secure settings:
+   - Key type: RSA
+   - Key length: 4096 bits
+   - No expiration (suitable for long-term project encryption)
+   - No passphrase (for automated `chezmoi` operations)
+   - Name format: `<project-name>-chezmoi@localhost`
+3. Configure `.chezmoi.toml` with the GPG key ID for automatic encryption/decryption
+
+#### Adding Encrypted Files
+
+To encrypt a file, add it with the `--encrypt` flag:
 
 ```bash
 chezmoi --config ./.chezmoi.toml add --encrypt ~/.private-key
@@ -172,6 +231,50 @@ chezmoi --config ./.chezmoi.toml add --encrypt ~/.private-key
 
 When you run `chezmoi apply`, the file will be decrypted and placed in the correct
 location. The encrypted version remains safely in your git repository.
+
+#### Using Encryption in CI/CD Pipelines
+
+To use encrypted chezmoi files in CI/CD environments, you need to export your GPG
+key and configure it as a secret in your CI platform.
+
+##### Export your GPG private key
+
+```bash
+# List your GPG keys to find the KEY_ID (shown in bootstrap output)
+gpg --list-secret-keys --keyid-format LONG
+
+# Export the private key (replace KEY_ID with your actual key ID)
+gpg --export-secret-keys --armor <KEY_ID> > private-key.asc
+```
+
+##### Configure CI Secrets
+
+Add these secrets to your CI platform (GitHub Actions, GitLab CI, etc.):
+
+- `GPG_PRIVATE_KEY`: The contents of `private-key.asc`
+- `GPG_KEY_ID`: Your GPG key ID (optional, for verification)
+
+##### Import key in CI
+
+```bash
+# In your CI script (before running chezmoi apply)
+echo "$GPG_PRIVATE_KEY" | gpg --import --batch --yes
+
+# Verify the key was imported (optional)
+gpg --list-secret-keys "$GPG_KEY_ID"
+
+# Now you can run chezmoi apply
+chezmoi --config ./.chezmoi.toml apply
+```
+
+##### Security Notes
+
+- **Never commit the private key used to manage chezmoi encryption to git, all
+  other private keys included should be themselves encrypted**
+- Delete `private-key.asc` after adding it to CI secrets
+- The generated keys have no passphrase for automation convenience, so protect
+  the CI secrets carefully
+- Consider using separate GPG keys for different environments (dev/staging/prod)
 
 ### WSL specific code within templates
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,9 @@ set -euf -o pipefail
 
 # --- Argument Parsing ---
 MODE=""
-# A simple loop to grab --mode
+ENABLE_ENCRYPTION=""
+GPG_KEY_ID=""
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --mode)
@@ -13,6 +15,20 @@ while [[ $# -gt 0 ]]; do
         shift 2
       else
         echo "Error: --mode requires a value." >&2
+        exit 1
+      fi
+      ;;
+    --encrypt)
+      ENABLE_ENCRYPTION="yes"
+      shift
+      ;;
+    --gpg-key)
+      if [[ -n "$2" && ! "$2" =~ ^-- ]]; then
+        GPG_KEY_ID="$2"
+        ENABLE_ENCRYPTION="yes"
+        shift 2
+      else
+        echo "Error: --gpg-key requires a value." >&2
         exit 1
       fi
       ;;
@@ -86,6 +102,12 @@ else
         add_project_args=("--dir" "$submodule_dir")
         if [ -n "$MODE" ]; then
             add_project_args+=("--mode" "$MODE")
+        fi
+        if [ "$ENABLE_ENCRYPTION" = "yes" ]; then
+            add_project_args+=("--encrypt")
+            if [ -n "$GPG_KEY_ID" ]; then
+                add_project_args+=("--gpg-key" "$GPG_KEY_ID")
+            fi
         fi
         "$SCRIPT_DIR/scripts/add_project.sh" "${add_project_args[@]}"
         SHOULD_APPLY=true

--- a/scripts/add_project.sh
+++ b/scripts/add_project.sh
@@ -7,6 +7,8 @@ SUBMODULE_DIR=".secrets" # Default value, can be overridden by --dir flag
 MODE=""
 ALLOWED_MODES=("local" "testing" "production")
 PARENT_REPOSITORY_REMOTE=$(git config --get remote.origin.url)
+ENABLE_ENCRYPTION=""
+GPG_KEY_ID=""
 
 # Helper function to check if a value is in an array
 contains_element() {
@@ -28,6 +30,8 @@ Options:
   --name <name>         The name for the new secrets git repository.
                         If not provided, you will be prompted.
   --dir <dir>           The local directory name for the submodule. Defaults to ".secrets".
+  --encrypt             Enable GPG encryption for chezmoi-managed files.
+  --gpg-key <key_id>    Use an existing GPG key ID. If not provided with --encrypt, a new key will be generated.
   -h, --help            Display this help message and exit.
 EOF
     exit 0
@@ -76,6 +80,62 @@ prompt_for_configuration() {
         exit 1
     fi
     echo "--> Repository name is available."
+
+    # Prompt for encryption setup if not provided via arguments
+    if [ -z "$ENABLE_ENCRYPTION" ]; then
+        echo ""
+        read -r -p "Enable GPG encryption for chezmoi-managed files? (y/N): " encrypt_response
+        if [[ "$encrypt_response" =~ ^[Yy]$ ]]; then
+            ENABLE_ENCRYPTION="yes"
+        else
+            ENABLE_ENCRYPTION="no"
+        fi
+    fi
+
+    # If encryption is enabled, handle GPG key setup
+    if [ "$ENABLE_ENCRYPTION" = "yes" ]; then
+        if [ -z "$GPG_KEY_ID" ]; then
+            echo ""
+            echo "GPG encryption is enabled. You can use an existing GPG key or generate a new one."
+            read -r -p "Use an existing GPG key? (y/N): " use_existing_key
+
+            if [[ "$use_existing_key" =~ ^[Yy]$ ]]; then
+                # List available GPG keys
+                echo ""
+                echo "Available GPG keys:"
+                gpg --list-secret-keys --keyid-format LONG
+                echo ""
+                read -r -p "Enter the GPG key ID to use: " GPG_KEY_ID
+
+                if [ -z "$GPG_KEY_ID" ]; then
+                    echo "Error: GPG key ID cannot be empty." >&2
+                    exit 1
+                fi
+
+                # Verify the key exists
+                if ! gpg --list-secret-keys "$GPG_KEY_ID" >/dev/null 2>&1; then
+                    echo "Error: GPG key '$GPG_KEY_ID' not found." >&2
+                    exit 1
+                fi
+            else
+                echo ""
+                echo "A new GPG key will be generated with the following settings:"
+                echo "  - Key type: RSA"
+                echo "  - Key length: 4096 bits"
+                echo "  - Expiration: No expiration"
+                echo "  - Name format: <project-name>-chezmoi"
+                echo ""
+                # GPG key will be generated in setup_gpg_encryption function
+            fi
+        # Verify the provided key exists
+        elif ! gpg --list-secret-keys "$GPG_KEY_ID" >/dev/null 2>&1; then
+            echo "Error: Provided GPG key '$GPG_KEY_ID' not found." >&2
+            exit 1
+        fi
+
+        # Setup GPG encryption now that we have all the configuration
+        setup_gpg_encryption
+    fi
 }
 
 make_new_folder() {
@@ -89,6 +149,97 @@ make_new_folder() {
         exit 1
     fi
     echo "--> Directory '$dir_name' created."
+}
+
+setup_gpg_encryption() {
+    # Generate a new GPG key if one wasn't provided
+    if [ -z "$GPG_KEY_ID" ]; then
+        local key_name="${SUBMODULE_NAME}-chezmoi"
+        local key_email="${SUBMODULE_NAME}-chezmoi@localhost"
+
+        # Check if a key with this email already exists
+        local existing_key_count
+        existing_key_count=$(gpg --list-secret-keys --with-colons "$key_email" 2>/dev/null | grep -c "^sec:")
+
+        if [ "$existing_key_count" -gt 0 ]; then
+            echo "A GPG key with email '$key_email' already exists."
+
+            if [ "$existing_key_count" -eq 1 ]; then
+                # Exactly one key found - offer to reuse it
+                local existing_key_id
+                existing_key_id=$(gpg --list-secret-keys --with-colons "$key_email" | awk -F: '/^sec:/ {print $5; exit}')
+
+                echo "Found existing key: $existing_key_id"
+                read -r -p "Reuse this key for chezmoi encryption? (Y/n): " reuse_key
+
+                if [[ ! "$reuse_key" =~ ^[Nn]$ ]]; then
+                    GPG_KEY_ID="$existing_key_id"
+                    echo "--> Using existing GPG key: $GPG_KEY_ID"
+                    return 0
+                fi
+            else
+                # Multiple keys found
+                echo "Multiple keys found with this email. Please choose a unique email or select an existing key."
+            fi
+
+            # User chose not to reuse or multiple keys exist - prompt for unique email
+            echo ""
+            read -er -p "Enter a unique email for the new GPG key: " -i "${SUBMODULE_NAME}-chezmoi-$(date +%s)@localhost" key_email
+
+            if [ -z "$key_email" ]; then
+                echo "Error: Email cannot be empty." >&2
+                exit 1
+            fi
+
+            # Re-check the new email
+            existing_key_count=$(gpg --list-secret-keys --with-colons "$key_email" 2>/dev/null | grep -c "^sec:")
+            if [ "$existing_key_count" -gt 0 ]; then
+                echo "Error: Email '$key_email' is still not unique. Please delete existing keys or choose a different email." >&2
+                exit 1
+            fi
+        fi
+
+        echo "--> Generating new GPG key for chezmoi encryption..."
+        echo "    Name: $key_name"
+        echo "    Email: $key_email"
+
+        # Create GPG key generation batch file with predefined settings
+        local gpg_batch_file
+        gpg_batch_file=$(mktemp)
+        cat > "$gpg_batch_file" <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: $key_name
+Name-Email: $key_email
+Expire-Date: 0
+%commit
+EOF
+
+        # Generate the key
+        if ! gpg --batch --generate-key "$gpg_batch_file" 2>&1; then
+            echo "Error: Failed to generate GPG key." >&2
+            rm -f "$gpg_batch_file"
+            exit 1
+        fi
+
+        rm -f "$gpg_batch_file"
+
+        # Get the key ID of the newly generated key using colon-delimited output
+        # Field 5 contains the key ID in lines starting with 'sec:'
+        GPG_KEY_ID=$(gpg --list-secret-keys --with-colons "$key_email" | awk -F: '/^sec:/ {print $5; exit}')
+
+        if [ -z "$GPG_KEY_ID" ]; then
+            echo "Error: Failed to retrieve generated GPG key ID." >&2
+            exit 1
+        fi
+
+        echo "--> GPG key generated successfully: $GPG_KEY_ID"
+    else
+        echo "--> Using existing GPG key: $GPG_KEY_ID"
+    fi
 }
 
 initialize_submodule_repo() {
@@ -134,6 +285,20 @@ initialize_submodule_repo() {
     fi
 
     make_new_folder "dot_chezmoi"
+
+    # Build encryption configuration if enabled
+    local encryption_config=""
+    if [ "$ENABLE_ENCRYPTION" = "yes" ]; then
+        encryption_config="# GPG encryption is enabled for this project
+encryption = \"gpg\"
+
+[gpg]
+# The GPG key ID used for encrypting chezmoi-managed files
+recipient = \"${GPG_KEY_ID}\"
+
+"
+    fi
+
     cat << EOF > ".chezmoi.toml.tmpl"
 # .chezmoi.toml
 # Local project configuration for chezmoi.
@@ -144,6 +309,7 @@ sourceDir = "./${SUBMODULE_DIR}"
 # The destination directory is the project root.
 destDir = "."
 
+${encryption_config}
 [data]
 # This value determines the operational mode for this project's configuration.
 # It will prompt on the first 'chezmoi apply' if a mode was not set during setup.
@@ -228,12 +394,30 @@ EOF
 }
 
 print_success_message() {
+    local encryption_msg=""
+    if [ "$ENABLE_ENCRYPTION" = "yes" ]; then
+        encryption_msg="
+🔐 GPG Encryption is enabled!
+   GPG Key ID: ${GPG_KEY_ID}
+
+   To add encrypted files, use the encrypted_ prefix:
+     chezmoi --config ./.chezmoi.toml add --encrypt file.txt
+   This will create 'encrypted_file.txt.age' in your secrets repository.
+
+   For CI/CD pipelines, you'll need to export and configure the GPG key.
+   See the README for detailed instructions on:
+     - Exporting the private key: gpg --export-secret-keys --armor ${GPG_KEY_ID}
+     - Configuring CI secrets (GPG_PRIVATE_KEY, GPG_KEY_ID)
+     - Importing keys in CI environments
+"
+    fi
+
     cat <<EOF
 
 ✅ Project setup complete!
 
 The secrets submodule has been created in '${SUBMODULE_DIR}' and '.chezmoi.toml' is configured.
-
+${encryption_msg}
 A 'dot_gitignore.tmpl' file has been created in your new secrets repository.
 This template will automatically generate a '.gitignore' file in your project root
 that lists all files managed by chezmoi.
@@ -282,6 +466,20 @@ while [[ $# -gt 0 ]]; do
                 shift 2
             else
                 echo "Error: --dir requires a value." >&2
+                usage
+            fi
+            ;;
+        --encrypt)
+            ENABLE_ENCRYPTION="yes"
+            shift
+            ;;
+        --gpg-key)
+            if [[ -n "$2" && ! "$2" =~ ^-- ]]; then
+                GPG_KEY_ID="$2"
+                ENABLE_ENCRYPTION="yes"
+                shift 2
+            else
+                echo "Error: --gpg-key requires a value." >&2
                 usage
             fi
             ;;

--- a/scripts/chezmoi-add-secret.sh
+++ b/scripts/chezmoi-add-secret.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configuration
+CHEZMOI_CONFIG=".chezmoi.toml"
+SOURCE_DIR=""
+ENCRYPT=false
+
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS] <file-path>
+
+Add files to chezmoi-managed repository from the project directory.
+
+This script solves the limitation where chezmoi won't add files from the
+directory it manages by copying them to the chezmoi source directory first.
+
+OPTIONS:
+    --encrypt       Add 'encrypted_' prefix to enable GPG encryption
+                    (requires GPG to be configured in .chezmoi.toml)
+    -h, --help      Show this help message
+
+ARGUMENTS:
+    file-path       Relative or absolute path to the file to add
+
+EXAMPLES:
+    $0 .env
+    $0 --encrypt .env
+    $0 -h|--help
+
+DESCRIPTION:
+    This script:
+    1. Copies the file to the chezmoi source directory with proper naming
+    2. Converts dotfile names (e.g., .env -> dot_env)
+    3. Adds 'encrypted_' prefix if --encrypt is used
+    4. Applies changes to deploy the file back to the project
+    5. Stages the file in the chezmoi-managed git repository
+
+    Files with the 'encrypted_' prefix will be automatically encrypted
+    by chezmoi using GPG when applied.
+
+    The script must be run from the project root directory.
+EOF
+    exit 0
+}
+
+validate_environment() {
+    if [[ ! -f "$CHEZMOI_CONFIG" ]]; then
+        echo "Error: $CHEZMOI_CONFIG not found in current directory"
+        echo "Please run this script from the project root"
+        exit 1
+    fi
+
+    # Read sourceDir from chezmoi
+    SOURCE_DIR=$(chezmoi --config "$CHEZMOI_CONFIG" source-path)
+
+    if [[ -z "$SOURCE_DIR" ]]; then
+        echo "Error: Could not determine source directory from chezmoi"
+        exit 1
+    fi
+
+    if [[ ! -d "$SOURCE_DIR" ]]; then
+        echo "Error: Source directory $SOURCE_DIR not found"
+        exit 1
+    fi
+
+    # Check if encryption is configured when --encrypt flag is used
+    if [[ "$ENCRYPT" = true ]]; then
+        local encryption_type
+        encryption_type=$(chezmoi --config "$CHEZMOI_CONFIG" dump-config --format json | jq -r '.encryption // empty' 2>/dev/null)
+
+        if [[ -z "$encryption_type" ]]; then
+            echo "Error: --encrypt flag requires GPG encryption to be configured in $CHEZMOI_CONFIG"
+            echo "Run bootstrap with --encrypt flag to set up encryption, or see README for manual setup"
+            exit 1
+        fi
+    fi
+}
+
+parse_arguments() {
+    # Check for help flag first
+    if [[ $# -ge 1 ]] && { [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; }; then
+        usage
+    fi
+
+    if [[ $# -lt 1 ]] || [[ $# -gt 2 ]]; then
+        echo "Error: Invalid number of arguments"
+        usage
+    fi
+
+    # Parse arguments
+    if [[ "$1" = "--encrypt" ]]; then
+        ENCRYPT=true
+        if [[ $# -ne 2 ]]; then
+            echo "Error: --encrypt flag requires a file path"
+            usage
+        fi
+        INPUT_PATH="$2"
+    else
+        INPUT_PATH="$1"
+    fi
+}
+
+resolve_file_path() {
+    local input_path="$1"
+    
+    # Convert to absolute path
+    if [[ "$input_path" = /* ]]; then
+        ABSOLUTE_PATH="$input_path"
+    else
+        ABSOLUTE_PATH="$(cd "$(dirname "$input_path")" && pwd)/$(basename "$input_path")"
+    fi
+
+    # Check if file exists
+    if [[ ! -f "$ABSOLUTE_PATH" ]]; then
+        echo "Error: File does not exist: $ABSOLUTE_PATH"
+        exit 1
+    fi
+
+    # Get relative path from project root
+    RELATIVE_PATH="${ABSOLUTE_PATH#"$(pwd)"/}"
+
+    # If the path didn't change, the file is outside project root
+    if [[ "$RELATIVE_PATH" = "$ABSOLUTE_PATH" ]]; then
+        echo "Error: File must be within the project directory"
+        echo "File: $ABSOLUTE_PATH"
+        echo "Project root: $(pwd)"
+        exit 1
+    fi
+
+    # Remove leading ./
+    RELATIVE_PATH="${RELATIVE_PATH#./}"
+}
+
+convert_to_chezmoi_path() {
+    # Split the path into components and convert each one
+    IFS='/' read -ra PATH_PARTS <<< "$RELATIVE_PATH"
+    CHEZMOI_PARTS=()
+
+    for i in "${!PATH_PARTS[@]}"; do
+        part="${PATH_PARTS[$i]}"
+        if [[ -z "$part" ]]; then
+            continue
+        fi
+        
+        # For the last component (filename), add encrypted_ prefix if requested
+        if [[ $i -eq $((${#PATH_PARTS[@]} - 1)) ]] && [[ "$ENCRYPT" = true ]]; then
+            if [[ "$part" = .* ]]; then
+                # .env -> encrypted_dot_env
+                CHEZMOI_PARTS+=("encrypted_dot_${part#.}")
+            else
+                # secret.txt -> encrypted_secret.txt
+                CHEZMOI_PARTS+=("encrypted_$part")
+            fi
+        # For all other components, convert dots normally
+        elif [[ "$part" = .* ]]; then
+            # .config -> dot_config
+            CHEZMOI_PARTS+=("dot_${part#.}")
+        else
+            # No conversion needed for parts not starting with .
+            CHEZMOI_PARTS+=("$part")
+        fi
+    done
+
+    # Reconstruct the path
+    CHEZMOI_PATH=$(IFS=/; echo "${CHEZMOI_PARTS[*]}")
+    SOURCE_PATH="$SOURCE_DIR/$CHEZMOI_PATH"
+}
+
+copy_file() {
+    # Create directory structure in .secrets
+    SOURCE_DIR_PATH="$(dirname "$SOURCE_PATH")"
+    mkdir -p "$SOURCE_DIR_PATH"
+
+    # Check if file already exists in source
+    if [[ -f "$SOURCE_PATH" ]]; then
+        echo "Warning: File already exists in source: $SOURCE_PATH"
+        read -p "Overwrite? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Aborted."
+            exit 0
+        fi
+    fi
+
+    # If encryption is enabled, encrypt with chezmoi
+    if [[ "$ENCRYPT" = true ]]; then
+        echo "Encrypting file..."
+        if chezmoi --config "$CHEZMOI_CONFIG" encrypt "$ABSOLUTE_PATH" --output "$SOURCE_PATH"; then
+            echo "File encrypted successfully"
+        else
+            echo "Error: Encryption failed"
+            exit 1
+        fi
+    else
+        # Copy file to source without encryption
+        cp "$ABSOLUTE_PATH" "$SOURCE_PATH"
+    fi
+
+    echo "Successfully added file to chezmoi source"
+    echo "  Source file: $RELATIVE_PATH"
+    echo "  Chezmoi path: $SOURCE_PATH"
+    echo ""
+}
+
+apply_changes() {
+    echo "Applying changes..."
+    if chezmoi --config "$CHEZMOI_CONFIG" apply "$RELATIVE_PATH"; then
+        echo "Chezmoi changes applied successfully"
+    else
+        echo "Warning: Apply failed, but file was added to source"
+    fi
+}
+
+stage_in_git() {
+    echo "Staging file in .secrets repo..."
+    if chezmoi --config "$CHEZMOI_CONFIG" git -- add "$CHEZMOI_PATH"; then
+        echo "File staged with chezmoi"
+        echo "Next steps: review, commit, and push!"
+    else
+        echo "Warning: Failed to stage file in git"
+    fi
+}
+
+# Execute
+parse_arguments "$@"
+validate_environment
+resolve_file_path "$INPUT_PATH"
+convert_to_chezmoi_path
+copy_file
+apply_changes
+stage_in_git


### PR DESCRIPTION
There is a limitation to chezmoi where it will not allow for adding a file to the source repository from the destination directory. This makes some things more difficult like developing a file in its correct location in the parent repository and then including it in the source repository. The chezmoi-add-secret.sh script handles this with options for encyption.

This PR also adds flags to allow for setting up the encryption functionality within the source repository when running the bootstrap and add_project scripts. The user has options of generating new GPG keys and using preexisting keys.