### PR TITLE
chore: reverse parts in bitwarden env filename

### DIFF
--- a/BITWARDEN.md
+++ b/BITWARDEN.md
@@ -18,13 +18,13 @@ This project uses Bitwarden CLI to manage secrets with chezmoi.
    - Click **View API Key**
    - Copy your `client_id`, `client_secret`
 
-2. Create `.bitwarden.env` file:
+2. Create `.env.bitwarden` file:
 
    ```bash
-   cp .bitwarden.env.example .bitwarden.env
+   cp .env.bitwarden.example .env.bitwarden
    ```
 
-3. Edit `.bitwarden.env` and add your credentials:
+3. Edit `.env.bitwarden` and add your credentials:
 
    ```bash
    BW_CLIENTID=user.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -92,12 +92,12 @@ In CI environments, set these as secrets:
 - `BW_CLIENTSECRET`
 - `BW_PASSWORD`
 
-Then source the script as normal - it will use environment variables if `.bitwarden.env`
+Then source the script as normal - it will use environment variables if `.env.bitwarden`
 doesn't exist.
 
 ## Security Notes
 
-- `.bitwarden.env` is gitignored - never commit it
+- `.env.bitwarden` is gitignored - never commit it
 - Store your master password securely
 - Consider using a separate Bitwarden organization for CI secrets
 - Use `bw lock` when done to secure your vault

--- a/scripts/source_bitwarden_session.sh
+++ b/scripts/source_bitwarden_session.sh
@@ -22,7 +22,7 @@ if [ -z "$PROJECT_ROOT" ]; then
     return 1
 fi
 
-ENV_FILE="$PROJECT_ROOT/.bitwarden.env"
+ENV_FILE="$PROJECT_ROOT/.env.bitwarden"
 
 # Check if Bitwarden CLI is installed
 if ! command -v bw &> /dev/null; then
@@ -30,14 +30,14 @@ if ! command -v bw &> /dev/null; then
     return 1
 fi
 
-# Load Bitwarden credentials from .bitwarden.env if it exists
+# Load Bitwarden credentials from .env.bitwarden if it exists
 if [ -f "$ENV_FILE" ]; then
     set -a
     # shellcheck source=/dev/null
     source "$ENV_FILE"
     set +a
 elif [ -z "$BW_CLIENTID" ] || [ -z "$BW_CLIENTSECRET" ]; then
-    echo "Error: Create .bitwarden.env: cp .bitwarden.env.example .bitwarden.env" >&2
+    echo "Error: Create .env.bitwarden: cp .env.bitwarden.example .env.bitwarden" >&2
     return 1
 fi
 


### PR DESCRIPTION
To better work with the dotenv vscode extension I have reversed the filename parts for the bitwarden env file from `.bitwarden.env` to `.env.bitwarden`.