### PR TITLE
Harden bootstrap scripts for non-interactive CI + SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security
+
+## Reporting a vulnerability
+
+Open a [private security advisory](https://github.com/SymbionicNigel/dotfile-utils/security/advisories/new),
+or email the maintainer. Please do not file public issues for security reports.
+
+## Enabled controls
+
+- **Secret scanning + push protection** — commits pushed with a detectable
+  credential are blocked; historical leaks are flagged in the Security tab.
+- **Dependabot security updates** — automatic PRs for vulnerable dependencies.
+- **Branch protection on `master`** — changes land via pull request;
+  force-pushes and deletions are disabled. This repo has no CI, so no status
+  check is required. Admins may merge directly.
+- **Merged branches are auto-deleted.**

--- a/scripts/install_bw_cli.sh
+++ b/scripts/install_bw_cli.sh
@@ -15,8 +15,11 @@ EOF
 }
 
 get_latest_version() {
-    # Use gh CLI to get latest release tag for CLI
-    gh release list --repo bitwarden/clients --limit 1 --json tagName --jq '.[0].tagName' | grep -oP 'cli-v\K[0-9.]+'
+    # bitwarden/clients is a monorepo (desktop-/browser-/cli-/web-v tags), so
+    # the newest release overall is often not the CLI. Scan recent releases and
+    # take the newest cli-v tag rather than assuming the top one is the CLI.
+    gh release list --repo bitwarden/clients --limit 100 --json tagName \
+        --jq 'map(.tagName | select(startswith("cli-v")))[0]' | grep -oP 'cli-v\K[0-9.]+'
 }
 
 get_installed_version() {

--- a/scripts/install_chezmoi.sh
+++ b/scripts/install_chezmoi.sh
@@ -9,6 +9,13 @@
 #
 set -euf
 
+# Non-interactive guard: refuse to silently fall through to a prompt-driven
+# path when there's no TTY and no fork user / CI override to work from.
+if [ ! -t 0 ] && [ "${CI:-}" != "true" ] && [ -z "${CHEZMOI_FORK_USER:-}" ]; then
+  echo "Error: non-interactive invocation requires CHEZMOI_FORK_USER or CI=true." >&2
+  exit 1
+fi
+
 usage() {
     cat <<EOF
 Usage: $(basename "$0") [-h|--help]
@@ -33,7 +40,7 @@ EOF
 # --- Configuration ---
 # Pin the exact version of chezmoi you want to use.
 # Find versions at: https://github.com/twpayne/chezmoi/releases
-CHEZMOI_VERSION="v2.63.0" # Must be full version identifier!!
+CHEZMOI_VERSION="v2.70.5" # Must be full version identifier!!
 ORIGINAL_REPO="twpayne/chezmoi"
 INSTALL_DIR="${HOME}/.local/bin"
 
@@ -176,9 +183,12 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 1
 fi
 
-# Dynamically determine the user's GitHub username and set the fork repository
-GITHUB_USER=$(gh config get user -h github.com)
-FORK_REPO="${GITHUB_USER}/chezmoi"
+# Which GitHub user owns the chezmoi fork. Override via CHEZMOI_FORK_USER for
+# CI or shared installs (e.g. the repo owner); defaults to the locally-
+# authenticated user. The default expansion only runs when the override is
+# unset, so CI never calls `gh config get user` as the bot.
+CHEZMOI_FORK_USER="${CHEZMOI_FORK_USER:-$(gh config get user -h github.com)}"
+FORK_REPO="${CHEZMOI_FORK_USER}/chezmoi"
 
 if command -v chezmoi >/dev/null 2>&1; then
   # chezmoi --version output is "chezmoi version v2.48.0, commit..."
@@ -203,10 +213,16 @@ case "${ARCH}" in
 esac
 
 # --- Mirroring and Installation ---
-echo "--- Ensuring personal artifact mirror is up to date ---"
-ensure_fork_exists "$FORK_REPO"
-
-ensure_release_mirrored "$FORK_REPO"
+# In CI the authenticated user is the bot, which can't create forks/releases.
+# It can still read the public fork, so skip the write path; the maintainer is
+# responsible for mirroring a new pinned version locally before CI needs it.
+if [ "${CI:-}" = "true" ]; then
+  echo "CI mode: skipping fork/release management (read-only from ${FORK_REPO})."
+else
+  echo "--- Ensuring personal artifact mirror is up to date ---"
+  ensure_fork_exists "$FORK_REPO"
+  ensure_release_mirrored "$FORK_REPO"
+fi
 
 # --- Download and Install ---
 echo "--- Installing chezmoi for local system (${OS}-${ARCH}) ---"

--- a/scripts/install_gh_cli.sh
+++ b/scripts/install_gh_cli.sh
@@ -43,7 +43,7 @@ install_gh_cli() {
         case "$PKG_MANAGER" in
             'apt-get')
                 sudo apt-get update > /dev/null
-                sudo apt-get install gh > /dev/null
+                sudo apt-get install -y gh > /dev/null
                 ;;
             *)
                 ;;

--- a/scripts/source_bitwarden_session.sh
+++ b/scripts/source_bitwarden_session.sh
@@ -41,6 +41,14 @@ elif [ -z "$BW_CLIENTID" ] || [ -z "$BW_CLIENTSECRET" ]; then
     return 1
 fi
 
+# Non-interactive guard: refuse to silently block on the `bw unlock` prompt.
+# Runs after .env.bitwarden is sourced so a local non-interactive caller can
+# still supply BW_PASSWORD there; CI supplies it directly via env.
+if [ ! -t 0 ] && [ -z "${BW_PASSWORD:-}" ]; then
+    echo "Error: BW_PASSWORD env var required when sourcing this script non-interactively (e.g. in CI)." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # Check Bitwarden status and authenticate/unlock as needed
 BW_STATUS=$(bw status 2>/dev/null | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
 


### PR DESCRIPTION
## Summary
Makes the install/bootstrap scripts safe to run unattended in GitHub Actions
(they're invoked by personal-infrastructure's deploy workflow), bumps the pinned
chezmoi version, hardens the Bitwarden CLI lookup, and documents the repo's
security posture.

## Changes
- **Non-interactive guards** so scripts fail fast instead of hanging on a prompt
  when there's no TTY:
  - `install_chezmoi.sh`: refuses to fall through to a prompt-driven path unless
    `CI=true` or `CHEZMOI_FORK_USER` is set; adds a `CHEZMOI_FORK_USER` override
    so CI never calls `gh config get user` as the bot; in CI mode skips the
    fork/release **mirror write path** and reads the pinned release from the
    public fork (the bot can't create forks/releases).
  - `source_bitwarden_session.sh`: requires `BW_PASSWORD` when sourced without a
    TTY rather than blocking on `bw unlock`.
  - `install_gh_cli.sh`: `apt-get install -y gh` (no interactive confirm).
- **`install_bw_cli.sh`**: widen the release search — the newest release on the
  `bitwarden/clients` repo often isn't the CLI, so scan recent releases for the
  right tag.
- **Pin bump**: `CHEZMOI_VERSION` `v2.63.0` → `v2.70.5`.
- **`SECURITY.md`**: documents enabled controls (secret scanning + push
  protection, Dependabot security updates, PR-gated `master`, auto-delete merged
  branches) and how to report.

## Notes
`master` is now branch-protected (PR required), which is why this lands as a PR.